### PR TITLE
Viewports as a Render texture

### DIFF
--- a/Core.cs
+++ b/Core.cs
@@ -12,7 +12,6 @@ using IceSaw2.Utilities;
 using ImGuiNET;
 using Raylib_cs;
 using rlImGui_cs;
-using System.Diagnostics;
 using System.Numerics;
 
 namespace IceSaw2
@@ -27,7 +26,7 @@ namespace IceSaw2
         private Vector2 _lastViewportSize = Vector2.Zero;
 
         //--------------------- Manager/Module/System declarations here -------------------------
-        public static TrickyWorldManager? worldManager = null;
+        private static TrickyWorldManager? _worldManager = null;
 
         public Core()
         {
@@ -51,7 +50,7 @@ namespace IceSaw2
 
             FontLoader InterNewFont = new();
 
-            rlImGui.SetupUserFonts += (ImGuiIOPtr imGuiIo) =>
+            rlImGui.SetupUserFonts += imGuiIo =>
             {
                 var io = ImGui.GetIO();
                 io.Fonts.Clear();
@@ -65,9 +64,8 @@ namespace IceSaw2
             }
 
             //--------------------- Manager/Module/System initializations here -------------------------
-            worldManager = new TrickyWorldManager();
+            _worldManager = new TrickyWorldManager();
         }
-
 
         public void Exiting()
         {
@@ -76,7 +74,6 @@ namespace IceSaw2
             rlImGui.Shutdown();
             Raylib.CloseWindow();
         }
-        
 
         public void InputProccessing()
         {
@@ -87,25 +84,22 @@ namespace IceSaw2
             // Can change State from here.
         }
 
-
         public void LogicProccessing()
         {
             // Set the isRunning variable to exit loop.
             // Can change State from here.
             // Communicate with other modules and managers.
-
-            if (worldManager != null)
+            if (_worldManager != null)
             {
-                switch (worldManager.windowMode)
+                switch (_worldManager.windowMode)
                 {
-                    case TrickyWorldManager.WindowMode.World: worldManager.levelEditorWindow.LogicUpdate(); break;
-                    case TrickyWorldManager.WindowMode.Prefabs: worldManager.prefabEditorWindow.LogicUpdate(); break;
-                    case TrickyWorldManager.WindowMode.Logic: worldManager.logicEditorWindow.LogicUpdate(); break;
+                    case TrickyWorldManager.WindowMode.World: _worldManager.levelEditorWindow.LogicUpdate(); break;
+                    case TrickyWorldManager.WindowMode.Prefabs: _worldManager.prefabEditorWindow.LogicUpdate(); break;
+                    case TrickyWorldManager.WindowMode.Logic: _worldManager.logicEditorWindow.LogicUpdate(); break;
                 }
-                worldManager.UpdateLogic();
+                _worldManager.UpdateLogic();
             }
         }
-
 
         public void RenderProcessing()
         {
@@ -116,41 +110,41 @@ namespace IceSaw2
             // Update render texture if screen size changed
             Vector2 winPos = Vector2.Zero;
             Vector2 winSize = Vector2.Zero;
-            if (worldManager != null)
+
+            if (_worldManager != null)
             {
-                if (worldManager.windowMode == TrickyWorldManager.WindowMode.World)
+                switch (_worldManager.windowMode)
                 {
-                    winPos = worldManager.levelEditorWindow.winPos;
-                    winSize = worldManager.levelEditorWindow.winSize;
-                } else if (worldManager.windowMode == TrickyWorldManager.WindowMode.Prefabs)
-                {
-                    winPos = worldManager.prefabEditorWindow.winPos;
-                    winSize = worldManager.prefabEditorWindow.winSize;
+                    case TrickyWorldManager.WindowMode.World:
+                        winPos = _worldManager.levelEditorWindow.winPos;
+                        winSize = _worldManager.levelEditorWindow.winSize;
+                        break;
+                    case TrickyWorldManager.WindowMode.Prefabs:
+                        winPos = _worldManager.prefabEditorWindow.winPos;
+                        winSize = _worldManager.prefabEditorWindow.winSize;
+                        break;
                 }
-             }
+            }
 
             if (winPos != _lastViewportPos || winSize != _lastViewportSize)
             {
-                if (Raylib.IsRenderTextureValid(_viewportTexture))
-                {
-                    Raylib.UnloadRenderTexture(_viewportTexture);
-                }
+                if (Raylib.IsRenderTextureValid(_viewportTexture)) Raylib.UnloadRenderTexture(_viewportTexture);
                 _viewportTexture = Raylib.LoadRenderTexture((int)winSize.X, (int)winSize.Y);
                 _lastViewportPos = winPos;
                 _lastViewportSize = winSize;
-                // Note: Fov might not match since the camera is in the level editor class
+                // Note: Fov might not match since the camera is in the level editor class - and not accesible here
                 Rlgl.SetMatrixProjection(Raymath.MatrixPerspective(65, winSize.X/winSize.Y, Rlgl.GetCullDistanceNear(), Rlgl.GetCullDistanceFar()));
             }
 
             // Render viewport to texture
             Raylib.BeginTextureMode(_viewportTexture);
             Raylib.ClearBackground(new Color(120, 120, 120));
-            if (worldManager != null)
+            if (_worldManager != null)
             {
-                switch (worldManager.windowMode)
+                switch (_worldManager.windowMode)
                 {
-                    case TrickyWorldManager.WindowMode.World: worldManager.levelEditorWindow.RenderUpdate(); break;
-                    case TrickyWorldManager.WindowMode.Prefabs: worldManager.prefabEditorWindow.RenderUpdate(); break;
+                    case TrickyWorldManager.WindowMode.World: _worldManager.levelEditorWindow.RenderUpdate(); break;
+                    case TrickyWorldManager.WindowMode.Prefabs: _worldManager.prefabEditorWindow.RenderUpdate(); break;
                 }
              }
             Raylib.EndTextureMode();
@@ -162,15 +156,15 @@ namespace IceSaw2
                     new Rectangle(_lastViewportPos.X, _lastViewportPos.Y, _lastViewportSize.X, _lastViewportSize.Y),
                     Vector2.Zero, 0, Color.White);
             rlImGui.Begin();
-            if (worldManager != null)
+            if (_worldManager != null)
             {
-                switch (worldManager.windowMode)
+                switch (_worldManager.windowMode)
                 {
-                    case TrickyWorldManager.WindowMode.World: worldManager.levelEditorWindow.RenderUI(); break;
-                    case TrickyWorldManager.WindowMode.Prefabs: worldManager.prefabEditorWindow.RenderUI(); break;
-                    case TrickyWorldManager.WindowMode.Logic: worldManager.logicEditorWindow.RenderUpdate(); break;
+                    case TrickyWorldManager.WindowMode.World: _worldManager.levelEditorWindow.RenderUI(); break;
+                    case TrickyWorldManager.WindowMode.Prefabs: _worldManager.prefabEditorWindow.RenderUI(); break;
+                    case TrickyWorldManager.WindowMode.Logic: _worldManager.logicEditorWindow.RenderUpdate(); break;
                 }
-                worldManager.UpdateRender();
+                _worldManager.UpdateRender();
              }
             Raylib.DrawText("Beta Test", 12, Raylib.GetScreenWidth() - 20, 20, Color.Black);
             rlImGui.End();

--- a/Core.cs
+++ b/Core.cs
@@ -13,6 +13,7 @@ using ImGuiNET;
 using Raylib_cs;
 using rlImGui_cs;
 using System.Diagnostics;
+using System.Numerics;
 
 namespace IceSaw2
 {
@@ -21,10 +22,12 @@ namespace IceSaw2
         public const int MaxFps = 120;
 
         public bool isRunning = true;
+        private RenderTexture2D _viewportTexture;
+        private Vector2 _lastViewportPos = new();
+        private Vector2 _lastViewportSize = new();
 
         //--------------------- Manager/Module/System declarations here -------------------------
         public static TrickyWorldManager? worldManager = null;
-
 
         public Core()
         {
@@ -43,9 +46,10 @@ namespace IceSaw2
                                  (int)Settings.General.Instance.data.windowPositionY);
             Raylib.SetWindowSize((int)Settings.General.Instance.data.windowWidth,
                                  (int)Settings.General.Instance.data.windowHeight);
+            Raylib.SetWindowMinSize(1280, 720);
             Raylib.SetWindowState(windowFlags);
 
-            FontLoader InterNewFont = new FontLoader();
+            FontLoader InterNewFont = new();
 
             rlImGui.SetupUserFonts += (ImGuiIOPtr imGuiIo) =>
             {
@@ -109,23 +113,64 @@ namespace IceSaw2
             // Render props, terrain, paths, wireframe, skybox, and bounding boxes.
             // Render Imgui. Lock or anchor the Imgui scale to 1080p, no need to big resolution flexibility.
 
-            Raylib.BeginDrawing();
-            rlImGui.Begin();
-            Raylib.ClearBackground(new Color(120, 120, 120));
+            // Update render texture if screen size changed
+            Vector2 winPos = Vector2.Zero;
+            Vector2 winSize = Vector2.Zero;
+            if (worldManager != null)
+            {
+                if (worldManager.windowMode == TrickyWorldManager.WindowMode.World)
+                {
+                    winPos = worldManager.levelEditorWindow.winPos;
+                    winSize = worldManager.levelEditorWindow.winSize;
+                }
+             }
 
+            if (winPos != _lastViewportPos || winSize != _lastViewportSize)
+            {
+                if (Raylib.IsRenderTextureValid(_viewportTexture))
+                {
+                    Raylib.UnloadRenderTexture(_viewportTexture);
+                }
+                _viewportTexture = Raylib.LoadRenderTexture((int)winSize.X, (int)winSize.Y);
+                _lastViewportPos = winPos;
+                _lastViewportSize = winSize;
+                // Note: Fov might not math since the camera is in the level editor class
+                Rlgl.SetMatrixProjection(Raymath.MatrixPerspective(65, winSize.X/winSize.Y, Rlgl.GetCullDistanceNear(), Rlgl.GetCullDistanceFar()));
+            }
+
+            // Render viewport to texture
+            Raylib.BeginTextureMode(_viewportTexture);
+            Raylib.ClearBackground(new Color(120, 120, 120));
             if (worldManager != null)
             {
                 switch (worldManager.windowMode)
                 {
                     case TrickyWorldManager.WindowMode.World: worldManager.levelEditorWindow.RenderUpdate(); break;
                     case TrickyWorldManager.WindowMode.Prefabs: worldManager.prefabEditorWindow.RenderUpdate(); break;
+                }
+             }
+            Raylib.EndTextureMode();
+
+            // Render viewport texture and GUI
+            Raylib.BeginDrawing();
+            Raylib.DrawTexturePro(_viewportTexture.Texture,
+                    new Rectangle(0, 0, _viewportTexture.Texture.Width, -_viewportTexture.Texture.Height),
+                    new Rectangle(_lastViewportPos.X, _lastViewportPos.Y, _lastViewportSize.X, _lastViewportSize.Y),
+                    Vector2.Zero, 0, Color.White);
+            rlImGui.Begin();
+            if (worldManager != null)
+            {
+                switch (worldManager.windowMode)
+                {
+                    case TrickyWorldManager.WindowMode.World: worldManager.levelEditorWindow.RenderUI(); break;
+                    case TrickyWorldManager.WindowMode.Prefabs: worldManager.prefabEditorWindow.RenderUI(); break;
                     case TrickyWorldManager.WindowMode.Logic: worldManager.logicEditorWindow.RenderUpdate(); break;
                 }
                 worldManager.UpdateRender();
              }
-
             Raylib.DrawText("Beta Test", 12, Raylib.GetScreenWidth() - 20, 20, Color.Black);
             rlImGui.End();
+
             Raylib.EndDrawing();
         }
     }

--- a/Core.cs
+++ b/Core.cs
@@ -23,8 +23,8 @@ namespace IceSaw2
 
         public bool isRunning = true;
         private RenderTexture2D _viewportTexture;
-        private Vector2 _lastViewportPos = new();
-        private Vector2 _lastViewportSize = new();
+        private Vector2 _lastViewportPos = Vector2.Zero;
+        private Vector2 _lastViewportSize = Vector2.Zero;
 
         //--------------------- Manager/Module/System declarations here -------------------------
         public static TrickyWorldManager? worldManager = null;
@@ -122,6 +122,10 @@ namespace IceSaw2
                 {
                     winPos = worldManager.levelEditorWindow.winPos;
                     winSize = worldManager.levelEditorWindow.winSize;
+                } else if (worldManager.windowMode == TrickyWorldManager.WindowMode.Prefabs)
+                {
+                    winPos = worldManager.prefabEditorWindow.winPos;
+                    winSize = worldManager.prefabEditorWindow.winSize;
                 }
              }
 
@@ -134,7 +138,7 @@ namespace IceSaw2
                 _viewportTexture = Raylib.LoadRenderTexture((int)winSize.X, (int)winSize.Y);
                 _lastViewportPos = winPos;
                 _lastViewportSize = winSize;
-                // Note: Fov might not math since the camera is in the level editor class
+                // Note: Fov might not match since the camera is in the level editor class
                 Rlgl.SetMatrixProjection(Raymath.MatrixPerspective(65, winSize.X/winSize.Y, Rlgl.GetCullDistanceNear(), Rlgl.GetCullDistanceFar()));
             }
 

--- a/EditorWindows/LevelEditorWindow.cs
+++ b/EditorWindows/LevelEditorWindow.cs
@@ -96,8 +96,6 @@ namespace IceSaw2.EditorWindows
             }
 
             Raylib.EndMode3D();
-
-            // RenderUI();
         }
 
         public void RenderUI()

--- a/EditorWindows/LevelEditorWindow.cs
+++ b/EditorWindows/LevelEditorWindow.cs
@@ -19,6 +19,8 @@ namespace IceSaw2.EditorWindows
         private const float moveSpeedStep = 0.008f;
         private int screenWidth { get { return Raylib.GetScreenWidth(); } }
         private int screenHeight { get { return Raylib.GetScreenHeight(); } }
+        public Vector2 winPos;
+        public Vector2 winSize;
 
         private float axisLineSize = 1000f;
         private float nearClip = 0.1f;
@@ -95,7 +97,7 @@ namespace IceSaw2.EditorWindows
 
             Raylib.EndMode3D();
 
-            RenderUI();
+            // RenderUI();
         }
 
         public void RenderUI()
@@ -136,8 +138,6 @@ namespace IceSaw2.EditorWindows
             ImGui.End();
             //ImGui.PopStyleVar(2);
 
-
-
             // --- INSPECTOR ---
             ImGui.SetNextWindowPos(new System.Numerics.Vector2(vpPos.X + vpSize.X - inspectorWidth, menuBarHeight), ImGuiCond.Always);
             ImGui.SetNextWindowSize(new System.Numerics.Vector2(inspectorWidth, vpSize.Y /*Raylib.GetScreenHeight() - menuBarHeight*/), ImGuiCond.Always);
@@ -147,8 +147,6 @@ namespace IceSaw2.EditorWindows
             ImGui.Text("Inspector");
             ImGui.End();
             //ImGui.PopStyleVar(2);
-
-
 
             // --- VIEWPORT ---
             float centerX = vpPos.X + outlinerWidth;
@@ -162,8 +160,8 @@ namespace IceSaw2.EditorWindows
             ImGui.Begin("Viewport", flags |= ImGuiWindowFlags.MenuBar);
 
             var drawList = ImGui.GetWindowDrawList();
-            var winPos = ImGui.GetWindowPos();
-            var winSize = ImGui.GetWindowSize();
+            winPos = ImGui.GetWindowPos();
+            winSize = ImGui.GetWindowSize();
 
             //Vector2 headerTL = new Vector2(winPos.X, winPos.Y);
             //Vector2 headerBR = new Vector2(winPos.X + winSize.X, winPos.Y + viewportHeaderHeight);
@@ -174,7 +172,6 @@ namespace IceSaw2.EditorWindows
             //ImGui.Text("Viewport Header");
 
             //ImGui.SameLine();
-
             
             if (ImGui.BeginMenuBar())
             {

--- a/EditorWindows/ModelsEditorWindow.cs
+++ b/EditorWindows/ModelsEditorWindow.cs
@@ -127,8 +127,6 @@ namespace IceSaw2.EditorWindows
 
                 Raylib.EndMode3D();
             }
-
-            // RenderUI();
         }
 
         public void RenderUI()

--- a/EditorWindows/ModelsEditorWindow.cs
+++ b/EditorWindows/ModelsEditorWindow.cs
@@ -16,6 +16,8 @@ namespace IceSaw2.EditorWindows
         int ActiveModelIndex = -1;
         int ActiveSkyboxIndex = -1;
         int ActiveMaterialIndex = -1;
+        public Vector2 winPos;
+        public Vector2 winSize;
 
         List<int> selectedModelIndices = new List<int>();
 
@@ -126,7 +128,7 @@ namespace IceSaw2.EditorWindows
                 Raylib.EndMode3D();
             }
 
-            RenderUI();
+            // RenderUI();
         }
 
         public void RenderUI()
@@ -176,8 +178,8 @@ namespace IceSaw2.EditorWindows
             ImGui.Begin("Viewport", flags);
 
             var drawList = ImGui.GetWindowDrawList();
-            var winPos = ImGui.GetWindowPos();
-            var winSize = ImGui.GetWindowSize();
+            winPos = ImGui.GetWindowPos();
+            winSize = ImGui.GetWindowSize();
 
             Vector2 headerTL = new Vector2(winPos.X, winPos.Y);
             Vector2 headerBR = new Vector2(winPos.X + winSize.X, winPos.Y + viewportHeaderHeight);


### PR DESCRIPTION
Render the editor viewports into a render texture. That way they don't render behind the GUI panels & headers. 
Also renders the viewports with the correct projection matrix and aspect ratio. 